### PR TITLE
Fix PiCamera2Stream frame locking

### DIFF
--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -195,9 +195,12 @@ class PiCamera2Stream:
             while not self.frame_available:
                 self.condition.wait()
 
-            while self.lock:
-                self.frame_available = False
-                return self.frame
+        # Safely read the latest frame under lock protection
+        with self.lock:
+            frame = self.frame
+            self.frame_available = False
+
+        return frame
 
     def stop(self):
         self.stopped.set()


### PR DESCRIPTION
## Summary
- fix frame grabbing lock logic in `PiCamera2Stream.read`

## Testing
- `python -m compileall -q utils/ owl.py`