### PR TITLE
Fix frame locking in PiCamera2 stream

### DIFF
--- a/utils/video_manager.py
+++ b/utils/video_manager.py
@@ -195,9 +195,11 @@ class PiCamera2Stream:
             while not self.frame_available:
                 self.condition.wait()
 
-            while self.lock:
-                self.frame_available = False
-                return self.frame
+        with self.lock:
+            frame = self.frame
+            self.frame_available = False
+
+        return frame
 
     def stop(self):
         self.stopped.set()


### PR DESCRIPTION
## Summary
- fix PiCamera2Stream locking when returning frame

## Testing
- `python -m py_compile utils/video_manager.py`