### PR TITLE
Add MQTT multi-node UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ options. Detections are published as JSON messages and OWL listens for control
 commands (`start`, `stop`, `shutdown`) to allow a master PC or Raspberry Pi to
 coordinate multiple OWL nodes.
 
+### Multi-Node MQTT User Interface
+
+The `utils/mqtt_ui.py` script offers a simple command line interface for
+controlling up to 40 OWL nodes through a single MQTT broker. Install the optional
+`paho-mqtt` dependency and run a broker (e.g. `python -m utils.mqtt_broker`).
+
+Run the UI specifying the broker details and number of nodes:
+
+```bash
+python -m utils.mqtt_ui --host localhost --port 1883 --nodes 4
+```
+
+Inside the interface you can issue commands:
+
+- `start <id>` / `stop <id>` – enable or disable detections on a node
+- `shutdown <id>` – gracefully shut down a node
+- `all_on` / `all_off` – toggle all relays across nodes
+- `exit` – quit the interface
+
+Nodes listen on `owl/<id>/control` for commands and publish detections on
+`owl/<id>/detections`.
+
 # OWL Use Cases
 
 ## Vehicle-mounted spot spraying

--- a/notes/mqtt_manager_py_notes.txt
+++ b/notes/mqtt_manager_py_notes.txt
@@ -2,7 +2,7 @@
 Notes on mqtt_manager.py
 
 Summary completed on 29/05/2025
-Summary based on new file in current commit
+Summary based on commit d8ee5cd
 ################################################################################
 
 Purpose:
@@ -10,7 +10,7 @@ Purpose:
 - Supports subscribing to control topics for remote commands
 
 Key Classes/Functions:
-- MQTTManager: connect, publish, subscribe and manage the client loop
+- MQTTManager: connect, publish, publish_to_topic, subscribe and manage the client loop
 
 Dependencies:
 - paho-mqtt

--- a/notes/mqtt_ui_py_notes.txt
+++ b/notes/mqtt_ui_py_notes.txt
@@ -1,0 +1,18 @@
+################################################################################
+Notes on mqtt_ui.py
+
+Summary completed on 29/05/2025
+Summary based on new file in current commit
+################################################################################
+
+Purpose:
+- Provide an interactive CLI for controlling multiple OWL nodes via MQTT
+- Supports up to 40 nodes with broadcast commands to toggle all relays
+
+Key Functions:
+- main: parses arguments, connects to the broker and runs the command loop
+
+Dependencies:
+- utils.mqtt_manager
+- paho-mqtt
+- standard library argparse and logging modules

--- a/utils/mqtt_manager.py
+++ b/utils/mqtt_manager.py
@@ -52,6 +52,14 @@ class MQTTManager:
         except Exception as exc:  # pragma: no cover - network errors only
             self.logger.error(f"MQTT publish failed: {exc}")
 
+    def publish_to_topic(self, topic: str, payload: Dict[str, Any]) -> None:
+        """Publish a JSON payload to a specific topic."""
+        try:
+            message = json.dumps(payload)
+            self.client.publish(topic, message)
+        except Exception as exc:  # pragma: no cover - network errors only
+            self.logger.error(f"MQTT publish failed: {exc}")
+
     def disconnect(self) -> None:
         """Disconnect from the broker."""
         self.stop_loop()

--- a/utils/mqtt_ui.py
+++ b/utils/mqtt_ui.py
@@ -1,0 +1,79 @@
+import argparse
+import logging
+from typing import Any
+
+from utils.mqtt_manager import MQTTManager
+
+MAX_NODES = 40
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Interactive UI to control multiple OWL nodes via MQTT."""
+    parser = argparse.ArgumentParser(description="MQTT UI for multiple OWL nodes")
+    parser.add_argument("--host", default="localhost", help="MQTT broker host")
+    parser.add_argument("--port", type=int, default=1883, help="MQTT broker port")
+    parser.add_argument("--nodes", type=int, default=1, help="Number of OWL nodes (1-40)")
+    args = parser.parse_args()
+
+    if not 1 <= args.nodes <= MAX_NODES:
+        parser.error(f"--nodes must be between 1 and {MAX_NODES}")
+
+    manager = MQTTManager(host=args.host, port=args.port)
+    try:
+        manager.connect()
+    except Exception as exc:  # pragma: no cover - network access only
+        logger.error("Failed to connect to MQTT broker: %s", exc)
+        return
+
+    manager.start_loop()
+
+    print(f"Connected to MQTT broker at {args.host}:{args.port}")
+    print("Available commands:\n"
+          "  start <id>     - start detections on node\n"
+          "  stop <id>      - stop detections on node\n"
+          "  shutdown <id>  - shutdown node\n"
+          "  all_on         - turn all relays on\n"
+          "  all_off        - turn all relays off\n"
+          "  exit           - quit UI")
+
+    try:
+        while True:
+            try:
+                text = input("> ").strip()
+            except EOFError:
+                break
+
+            if text in {"exit", "quit"}:
+                break
+            if text == "all_on":
+                for node in range(1, args.nodes + 1):
+                    manager.publish_to_topic(f"owl/{node}/control", {"command": "all_on"})
+                continue
+            if text == "all_off":
+                for node in range(1, args.nodes + 1):
+                    manager.publish_to_topic(f"owl/{node}/control", {"command": "all_off"})
+                continue
+
+            parts = text.split()
+            if len(parts) == 2 and parts[0] in {"start", "stop", "shutdown"}:
+                try:
+                    node = int(parts[1])
+                except ValueError:
+                    print("Invalid node id")
+                    continue
+                if not 1 <= node <= args.nodes:
+                    print(f"Node id must be between 1 and {args.nodes}")
+                    continue
+                manager.publish_to_topic(f"owl/{node}/control", {"command": parts[0]})
+            else:
+                print("Unknown command")
+    finally:
+        manager.disconnect()
+        print("Disconnected from broker")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `publish_to_topic` helper in `MQTTManager`
- create `mqtt_ui.py` for controlling up to 40 OWL nodes via MQTT
- document UI usage in README
- add notes for new module and update existing notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`