### PR TITLE
Remove debug code

### DIFF
--- a/notes/algorithms_py_notes.txt
+++ b/notes/algorithms_py_notes.txt
@@ -19,4 +19,5 @@ Dependencies:
 - numpy
 - opencv-python
 - pywt (optional for wavelet blur)
+- Removed unused cv2.imshow debugging calls
 

--- a/notes/output_manager_py_notes.txt
+++ b/notes/output_manager_py_notes.txt
@@ -22,9 +22,7 @@ Classes:
 - RelayController
 
 Entrypoint:
-- Has __main__ check for testing status indicators
-- Sets testing flag via get_platform_config() if not on Raspberry Pi
-- Uses terminal messages instead of GPIO when in test mode
+- Removed __main__ test block used for manual status indicator testing
 
 TestRelay class:
 - Simulates relay hardware for testing

--- a/notes/vis_manager_py_notes.txt
+++ b/notes/vis_manager_py_notes.txt
@@ -19,4 +19,5 @@ Key Methods:
 Dependencies:
 - numpy
 - blessed (optional, falls back to BasicTerminal)
+- Removed demonstration __main__ block
 

--- a/utils/algorithms.py
+++ b/utils/algorithms.py
@@ -19,15 +19,10 @@ def exg(image):
     blue = image[:, :, 0].astype(np.float32)
     green = image[:, :, 1].astype(np.float32)
     red = image[:, :, 2].astype(np.float32)
-    # cv2.imshow('blue', blue.astype('uint8'))
-    # cv2.imshow('green', green.astype('uint8'))
-    # cv2.imshow('red', red.astype('uint8'))
 
     image_out = 2 * green - red - blue
     image_out = np.clip(image_out, 0, 255)
     image_out = image_out.astype('uint8')
-
-    # cv2.imshow('ExG', imgOut)
     return image_out
 
 def maxg(image):
@@ -69,7 +64,6 @@ def exg_standardised(image):
     image_out = np.where(image_out > 255, 255, image_out)
 
     image_out = image_out.astype('uint8')
-    # cv2.imshow('ExG Standardised', imgOut)
 
     return image_out
 
@@ -117,7 +111,6 @@ def exg_standardised_hue(image,
                        saturation_min=saturation_min, saturation_max=saturation_max,
                        invert_hue=invert_hue)
     image_out = hsv_thresh & image_out
-    # cv2.imshow('exhu', imgOut)
 
     return image_out
 
@@ -174,7 +167,6 @@ def hsv(image,
         hue_thresh = cv2.bitwise_not(hue_thresh)
 
     out_thresh = sat_thresh & val_thresh & hue_thresh
-    # cv2.imshow('HSV Out', outThresh)
     return out_thresh, True
 
 # for NIR images only
@@ -190,7 +182,6 @@ def gndvi(image):
     image_out = (NIR - green) / (NIR + green)
     image_out = cv2.normalize(image_out, None, alpha=0, beta=255, norm_type=cv2.NORM_MINMAX, dtype=cv2.CV_32F)
     image_out = image_out.astype('uint8')
-    cv2.imshow('gndvi', image_out)
     return image_out
 
 
@@ -231,7 +222,6 @@ def clahe_sat_val(image):
 
     claheImage = cv2.merge([hue, satCL, valCL])
     claheImage = cv2.cvtColor(claheImage, cv2.COLOR_HSV2BGR)
-    #cv2.imshow('CLAHE', claheImage)
     return claheImage
 
 def dgci(image):
@@ -259,9 +249,6 @@ def normalize_brightness(image, intensity=0.8):
     normalized = cv2.cvtColor(img_yuv, cv2.COLOR_YUV2BGR)
 
     # Return the normalized image
-    #stacked = np.hstack((image, normalized))
-    #cv2.imshow('normalised', stacked)
-    #cv2.waitKey(0)
 
     return normalized
 

--- a/utils/output_manager.py
+++ b/utils/output_manager.py
@@ -560,26 +560,3 @@ class RelayController:
     def stop(self):
         self.running = False
 
-
-if __name__ == "__main__":
-    print("Starting test of status indicators...")
-
-    # Test HeadlessStatusIndicator
-    print("\nTesting HeadlessStatusIndicator...")
-    headless_indicator = HeadlessStatusIndicator(save_directory="output")
-    headless_indicator.show_error(3)  # Show an error with 3 flashes
-    headless_indicator.stop()
-
-    # Test UteStatusIndicator
-    print("\nTesting UteStatusIndicator...")
-    ute_indicator = UteStatusIndicator(save_directory="output", record_led_pin='BOARD38', storage_led_pin='BOARD40')
-    ute_indicator.show_error(4)  # Show an error with 4 flashes
-    ute_indicator.stop()
-
-    # Test AdvancedStatusIndicator
-    print("\nTesting AdvancedStatusIndicator...")
-    advanced_indicator = AdvancedStatusIndicator(save_directory="output", status_led_pin='BOARD37')
-    advanced_indicator.show_error(2)  # Show an error with 2 flashes
-    advanced_indicator.stop()
-
-    print("\nTest complete.")

--- a/utils/vis_manager.py
+++ b/utils/vis_manager.py
@@ -68,11 +68,3 @@ class RelayVis:
     def close(self):
         print("\n", end='\n')
 
-if __name__ == "__main__":
-    box_drawer = RelayVis(relays=4)
-
-    for i in range(0, 100):
-        relay = np.random.randint(0, 4)
-        status = bool(np.random.randint(0, 2))
-        box_drawer.update(relay=relay, status=status)
-        time.sleep(0.01)


### PR DESCRIPTION
## Summary
- tidy up algorithms by removing unused display calls
- remove manual test harness from output_manager
- drop example main section from vis_manager
- update notes accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `test -d tests && pytest -q || echo 'no tests'`
