### PR TITLE
Fix Yocto dependency

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -17,7 +17,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
             build-essential chrpath socat cpio python3 python3-pip python3-pexpect \
-            xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa \
+            xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1 \
             libsdl1.2-dev pylint xterm
 
       - name: Set up Yocto environment

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -9,3 +9,4 @@ OpenWeedLocator packaging
 
 - Added docs/yocto.md with instructions for building an OWL Yocto image for multiple Raspberry Pi models.
 - Added a GitHub Actions workflow to build the OWL Yocto image.
+- Updated Yocto build workflow to install `libegl1` instead of the removed `libegl1-mesa` package.


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow to use `libegl1` instead of `libegl1-mesa`
- note workflow change in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`