### PR TITLE
Improve Yocto build docs

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
             build-essential chrpath socat cpio python3 python3-pip python3-pexpect \
             xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa \
-            libsdl1.2-dev pylint xterm
+            libsdl1.2-dev pylint xterm bc bison flex libssl-dev libncurses5-dev
 
       - name: Set up Yocto environment
         run: |
@@ -32,4 +32,10 @@ jobs:
           echo 'BBLAYERS += "${BSPDIR}/meta-raspberrypi"' >> conf/bblayers.conf
           echo 'MACHINE ?= "raspberrypi3"' >> conf/local.conf
           bitbake core-image-base
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: yocto-image
+          path: poky/build/tmp/deploy/images/**/core-image-base*.wic
 

--- a/docs/yocto.md
+++ b/docs/yocto.md
@@ -42,7 +42,18 @@ To build images for different models, set `MACHINE` to `raspberrypi0`, `raspberr
 IMAGE_INSTALL += "owl"
 ```
 
-## 4. Build the image
+## 4. Add a custom splash screen (optional)
+
+To show a branded splash screen on boot, enable the `psplash` package and point it at a custom PNG image:
+
+```bash
+IMAGE_INSTALL += "psplash"
+SPLASH = "file://path/to/my_splash.png"
+```
+
+Place your splash image in your layer under `recipes-core/psplash/files/` and update your recipe accordingly. This will display the image while the system boots into the simple framebuffer console.
+
+## 5. Build the image
 
 Run `bitbake` to build the desired image, such as `core-image-base` or a custom recipe:
 ```bash
@@ -50,7 +61,7 @@ bitbake core-image-base
 ```
 The resulting SD card image will be available under `tmp/deploy/images/<machine>/`.
 
-## 5. Flash and run
+## 6. Flash and run
 
 Write the generated `.wic` or `.sdimg` file to an SD card and boot your Raspberry Pi. The OWL application can then be launched according to the normal usage instructions.
 

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -9,3 +9,5 @@ OpenWeedLocator packaging
 
 - Added docs/yocto.md with instructions for building an OWL Yocto image for multiple Raspberry Pi models.
 - Added a GitHub Actions workflow to build the OWL Yocto image.
+- Workflow now uploads the generated image artifact.
+- Yocto guide includes steps for an optional custom psplash screen.


### PR DESCRIPTION
## Summary
- document how to add a psplash image in Yocto
- upload the Yocto image artifact from CI
- record packaging notes update

## Testing
- `python -m py_compile $(git ls-files '*.py')`
