### PR TITLE
Fix artifact action version

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -34,7 +34,7 @@ jobs:
           bitbake core-image-base
 
       - name: Upload image artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: yocto-image
           path: poky/build/tmp/deploy/images/**/core-image-base*.wic

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -11,3 +11,4 @@ OpenWeedLocator packaging
 - Added a GitHub Actions workflow to build the OWL Yocto image.
 - Workflow now uploads the generated image artifact.
 - Yocto guide includes steps for an optional custom psplash screen.
+- Updated workflow to use actions/upload-artifact@v4 to fix download issue.


### PR DESCRIPTION
## Summary
- fix Yocto workflow by switching to `actions/upload-artifact@v4`
- document workflow update in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
