### PR TITLE
Fix Yocto build dependencies

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -17,7 +17,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
             build-essential chrpath socat cpio python3 python3-pip python3-pexpect \
-            xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa \
+            xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1 \
             libsdl1.2-dev pylint xterm bc bison flex libssl-dev libncurses5-dev
 
       - name: Set up Yocto environment

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -12,3 +12,5 @@ OpenWeedLocator packaging
 - Workflow now uploads the generated image artifact.
 - Yocto guide includes steps for an optional custom psplash screen.
 - Updated workflow to use actions/upload-artifact@v4 to fix download issue.
+
+- Updated Yocto build workflow to use libegl1 on Ubuntu 24.04.


### PR DESCRIPTION
## Summary
- update Yocto workflow dependency list to install `libegl1` instead of the obsolete `libegl1-mesa`
- document workflow change in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`