### PR TITLE
Fix Yocto workflow clone URLs

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -22,9 +22,9 @@ jobs:
 
       - name: Set up Yocto environment
         run: |
-          git clone --branch kirkstone git://git.yoctoproject.org/poky poky
+          git clone --branch kirkstone https://git.yoctoproject.org/git/poky.git poky
           cd poky
-          git clone --branch kirkstone git://git.openembedded.org/meta-openembedded
+          git clone --branch kirkstone https://git.openembedded.org/meta-openembedded
           git clone --branch kirkstone https://github.com/agherzan/meta-raspberrypi
           source oe-init-build-env build
           echo 'BBLAYERS += "${BSPDIR}/meta-openembedded/meta-oe"' >> conf/bblayers.conf

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -14,3 +14,4 @@ OpenWeedLocator packaging
 - Updated workflow to use actions/upload-artifact@v4 to fix download issue.
 
 - Updated Yocto build workflow to use libegl1 on Ubuntu 24.04.
+- Switched Yocto workflow clones to use HTTPS to avoid network restrictions.


### PR DESCRIPTION
## Summary
- update GitHub Action to clone Yocto layers over HTTPS
- document the update in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`