### PR TITLE
Fix Yocto layer paths in workflow

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -27,9 +27,9 @@ jobs:
           git clone --branch kirkstone git://git.openembedded.org/meta-openembedded
           git clone --branch kirkstone https://github.com/agherzan/meta-raspberrypi
           source oe-init-build-env build
-          echo 'BBLAYERS += "${BSPDIR}/meta-openembedded/meta-oe"' >> conf/bblayers.conf
-          echo 'BBLAYERS += "${BSPDIR}/meta-openembedded/meta-python"' >> conf/bblayers.conf
-          echo 'BBLAYERS += "${BSPDIR}/meta-raspberrypi"' >> conf/bblayers.conf
+          echo 'BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-oe"' >> conf/bblayers.conf
+          echo 'BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-python"' >> conf/bblayers.conf
+          echo 'BBLAYERS += "${TOPDIR}/../meta-raspberrypi"' >> conf/bblayers.conf
           echo 'MACHINE ?= "raspberrypi3"' >> conf/local.conf
           bitbake core-image-base
 

--- a/docs/yocto.md
+++ b/docs/yocto.md
@@ -21,11 +21,13 @@ This guide outlines the basic steps for creating a custom Yocto image for runnin
 
 ## 2. Configure layers
 
-Edit `conf/bblayers.conf` in the build directory to include the new layers:
+Edit `conf/bblayers.conf` in the build directory to include the new layers.
+Use paths relative to the build directory so that BitBake can locate the
+cloned layers:
 ```bash
-BBLAYERS += "${BSPDIR}/meta-openembedded/meta-oe"
-BBLAYERS += "${BSPDIR}/meta-openembedded/meta-python"
-BBLAYERS += "${BSPDIR}/meta-raspberrypi"
+BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-oe"
+BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-python"
+BBLAYERS += "${TOPDIR}/../meta-raspberrypi"
 ```
 
 Configure the machine type in `conf/local.conf` for the desired Raspberry Pi model, for example:


### PR DESCRIPTION
## Summary
- fix relative layer paths in Yocto build workflow
- clarify doc instructions with `${TOPDIR}` paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`