### PR TITLE
Fix bitbake AppArmor error

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -27,6 +27,7 @@ jobs:
           git clone --branch kirkstone git://git.openembedded.org/meta-openembedded
           git clone --branch kirkstone https://github.com/agherzan/meta-raspberrypi
           source oe-init-build-env build
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
           echo 'BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-oe"' >> conf/bblayers.conf
           echo 'BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-python"' >> conf/bblayers.conf
           echo 'BBLAYERS += "${TOPDIR}/../meta-raspberrypi"' >> conf/bblayers.conf

--- a/docs/yocto.md
+++ b/docs/yocto.md
@@ -18,6 +18,11 @@ This guide outlines the basic steps for creating a custom Yocto image for runnin
    ```bash
    source oe-init-build-env
    ```
+4. If BitBake reports that user namespaces are not usable (for example on
+   Ubuntu systems with AppArmor restrictions), enable them with:
+   ```bash
+   sudo sysctl -w kernel.unprivileged_userns_clone=1
+   ```
 
 ## 2. Configure layers
 

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -14,3 +14,6 @@ OpenWeedLocator packaging
 - Updated workflow to use actions/upload-artifact@v4 to fix download issue.
 
 - Updated Yocto build workflow to use libegl1 on Ubuntu 24.04.
+- Added instructions to enable unprivileged user namespaces when BitBake
+  reports an AppArmor error, and updated the workflow to set
+  `kernel.unprivileged_userns_clone=1`.


### PR DESCRIPTION
## Summary
- document how to enable unprivileged user namespaces when bitbake fails
- ensure GitHub Actions workflow enables the namespace feature
- record the change in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`