### PR TITLE
Fix Yocto CI on GH actions

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-yocto:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -17,3 +17,4 @@ OpenWeedLocator packaging
 - Added instructions to enable unprivileged user namespaces when BitBake
   reports an AppArmor error, and updated the workflow to set
   `kernel.unprivileged_userns_clone=1`.
+- Pinned GitHub Actions runner to ubuntu-22.04 to avoid AppArmor user namespace issue.


### PR DESCRIPTION
## Summary
- run Yocto build workflow on `ubuntu-22.04` to avoid AppArmor namespace errors
- note the runner pin in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`