### PR TITLE
Add self-hosted runner docs

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-yocto:
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ These will be updated as major changes are made. All older versions will be reta
 [View all versions](docs)
 
 * [Yocto build guide](docs/yocto.md)
+* [Self-hosted GitHub runner setup](docs/self-hosted-runner.md)
 
 ### MQTT Integration (Experimental)
 

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -1,0 +1,28 @@
+# Setting Up a Self-Hosted GitHub Runner
+
+The Yocto build workflow can run on a self-hosted runner. Use this approach when you need custom hardware or more control over the build environment.
+
+## 1. Install the Runner
+
+1. Create a directory for the runner and download the latest release:
+   ```bash
+   mkdir actions-runner && cd actions-runner
+   curl -o actions-runner-linux-x64-2.317.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.317.0/actions-runner-linux-x64-2.317.0.tar.gz
+   tar xzf actions-runner-linux-x64-2.317.0.tar.gz
+   ```
+2. Configure the runner, replacing the URL and token with values from your repository settings:
+   ```bash
+   ./config.sh --url https://github.com/your-user/OpenWeedLocator --token YOUR_TOKEN
+   ```
+3. Start the runner service:
+   ```bash
+   ./run.sh
+   ```
+
+## 2. Runner Labels
+
+The repository's Yocto build workflow runs on a runner labelled `self-hosted` and `linux`. Ensure your runner includes these labels in the configuration step above. Additional labels such as `x64` are optional but can help target specific hardware.
+
+## 3. Workflow Usage
+
+Once the runner is online, push changes to the repository. GitHub Actions will automatically dispatch the workflow to your self-hosted runner.

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -18,3 +18,4 @@ OpenWeedLocator packaging
   reports an AppArmor error, and updated the workflow to set
   `kernel.unprivileged_userns_clone=1`.
 - Pinned GitHub Actions runner to ubuntu-22.04 to avoid AppArmor user namespace issue.
+- Switched Yocto build workflow to a self-hosted runner using the `self-hosted` and `linux` labels.


### PR DESCRIPTION
## Summary
- add guide on setting up a self-hosted GitHub runner
- reference the new guide from the README
- note the workflow change in packaging notes
- run Yocto build workflow on a self-hosted runner with `linux` label

## Testing
- `python -m py_compile $(git ls-files '*.py')`