### PR TITLE
Fix Yocto workflow userns sysctl

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -27,7 +27,7 @@ jobs:
           git clone --branch kirkstone git://git.openembedded.org/meta-openembedded
           git clone --branch kirkstone https://github.com/agherzan/meta-raspberrypi
           source oe-init-build-env build
-          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
           echo 'BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-oe"' >> conf/bblayers.conf
           echo 'BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-python"' >> conf/bblayers.conf
           echo 'BBLAYERS += "${TOPDIR}/../meta-raspberrypi"' >> conf/bblayers.conf

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -19,3 +19,4 @@ OpenWeedLocator packaging
   `kernel.unprivileged_userns_clone=1`.
 - Pinned GitHub Actions runner to ubuntu-22.04 to avoid AppArmor user namespace issue.
 - Switched Yocto build workflow to a self-hosted runner using the `self-hosted` and `linux` labels.
+- Updated workflow to ignore errors when enabling unprivileged user namespaces.


### PR DESCRIPTION
## Summary
- keep Yocto workflow from failing when enabling user namespaces
- note the workflow change in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
