### PR TITLE
Document required Yocto host tools

### DIFF
--- a/docs/yocto.md
+++ b/docs/yocto.md
@@ -24,6 +24,12 @@ This guide outlines the basic steps for creating a custom Yocto image for runnin
    sudo sysctl -w kernel.unprivileged_userns_clone=1
    ```
 
+5. Ensure the host packages providing `lz4c`, `pzstd`, `unzstd` and `zstd`
+   are installed. On Debian/Ubuntu systems run:
+   ```bash
+   sudo apt-get install lz4 zstd
+   ```
+
 ## 2. Configure layers
 
 Edit `conf/bblayers.conf` in the build directory to include the new layers.
@@ -39,7 +45,8 @@ Configure the machine type in `conf/local.conf` for the desired Raspberry Pi mod
 ```bash
 MACHINE ?= "raspberrypi3"
 ```
-To build images for different models, set `MACHINE` to `raspberrypi0`, `raspberrypi2`, `raspberrypi3`, or `raspberrypi4` as needed.
+To build images for different models, set `MACHINE` to `raspberrypi0`,
+`raspberrypi2`, `raspberrypi3`, `raspberrypi4`, or `raspberrypi5` as needed.
 
 ## 3. Add OWL to the image
 

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -20,3 +20,4 @@ OpenWeedLocator packaging
 - Pinned GitHub Actions runner to ubuntu-22.04 to avoid AppArmor user namespace issue.
 - Switched Yocto build workflow to a self-hosted runner using the `self-hosted` and `linux` labels.
 - Updated workflow to ignore errors when enabling unprivileged user namespaces.
+- Documented host tool dependencies (lz4 and zstd) and Raspberry Pi 5 machine support in docs/yocto.md.


### PR DESCRIPTION
## Summary
- document lz4/zstd host tool packages in Yocto guide
- mention `raspberrypi5` machine option
- note these changes in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`