### PR TITLE
Document required host tools for Yocto

### DIFF
--- a/docs/yocto.md
+++ b/docs/yocto.md
@@ -2,6 +2,21 @@
 
 This guide outlines the basic steps for creating a custom Yocto image for running OpenWeedLocator (OWL) on Raspberry Pi models. These instructions assume familiarity with Yocto Project concepts and a Linux build host with the required dependencies installed.
 
+## Prerequisites
+
+Make sure the following host tools are installed so that BitBake can run:
+
+```bash
+sudo apt-get install lz4 zstd
+```
+
+These packages provide `lz4c`, `zstd`, `unzstd` and `pzstd`. If they are missing you may see an error like:
+
+```
+ERROR: The following required tools (as specified by HOSTTOOLS) appear to be unavailable in PATH
+```
+
+
 ## 1. Set up the Yocto environment
 
 1. Create a working directory and clone the Yocto Project `poky` repository:

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -20,3 +20,4 @@ OpenWeedLocator packaging
 - Pinned GitHub Actions runner to ubuntu-22.04 to avoid AppArmor user namespace issue.
 - Switched Yocto build workflow to a self-hosted runner using the `self-hosted` and `linux` labels.
 - Updated workflow to ignore errors when enabling unprivileged user namespaces.
+- Documented required host tools (lz4 and zstd) in docs/yocto.md to avoid HOSTTOOLS errors.


### PR DESCRIPTION
## Summary
- mention required host tools `lz4` and `zstd` in docs/yocto.md
- note new docs section in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`