### PR TITLE
Fix Yocto workflow missing host tools

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -18,7 +18,8 @@ jobs:
           sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
             build-essential chrpath socat cpio python3 python3-pip python3-pexpect \
             xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1 \
-            libsdl1.2-dev pylint xterm bc bison flex libssl-dev libncurses5-dev
+            libsdl1.2-dev pylint xterm bc bison flex libssl-dev libncurses5-dev \
+            lz4 zstd
 
       - name: Set up Yocto environment
         run: |

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -21,3 +21,5 @@ OpenWeedLocator packaging
 - Switched Yocto build workflow to a self-hosted runner using the `self-hosted` and `linux` labels.
 - Updated workflow to ignore errors when enabling unprivileged user namespaces.
 - Documented host tool dependencies (lz4 and zstd) and Raspberry Pi 5 machine support in docs/yocto.md.
+
+- Updated Yocto build workflow to install lz4 and zstd host tools.


### PR DESCRIPTION
## Summary
- install `lz4` and `zstd` packages in the Yocto build workflow
- note the change in the packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`