### PR TITLE
Add multi-board Yocto build and release upload

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -4,10 +4,15 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  release:
+    types: [published]
 
 jobs:
   build-yocto:
     runs-on: [self-hosted, linux]
+    strategy:
+      matrix:
+        machine: [raspberrypi3, raspberrypi4, raspberrypi5]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -32,7 +37,7 @@ jobs:
           echo 'BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-oe"' >> conf/bblayers.conf
           echo 'BBLAYERS += "${TOPDIR}/../meta-openembedded/meta-python"' >> conf/bblayers.conf
           echo 'BBLAYERS += "${TOPDIR}/../meta-raspberrypi"' >> conf/bblayers.conf
-          echo 'MACHINE ?= "raspberrypi3"' >> conf/local.conf
+          echo 'MACHINE ?= "${{ matrix.machine }}"' >> conf/local.conf
           bitbake core-image-base
 
       - name: Upload image artifact
@@ -40,4 +45,10 @@ jobs:
         with:
           name: yocto-image
           path: poky/build/tmp/deploy/images/**/core-image-base*.wic
+
+      - name: Upload release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: poky/build/tmp/deploy/images/**/core-image-base*.wic
 

--- a/docs/yocto.md
+++ b/docs/yocto.md
@@ -48,6 +48,20 @@ MACHINE ?= "raspberrypi3"
 To build images for different models, set `MACHINE` to `raspberrypi0`,
 `raspberrypi2`, `raspberrypi3`, `raspberrypi4`, or `raspberrypi5` as needed.
 
+If you require images for multiple boards, rerun the build with each desired
+`MACHINE` setting:
+
+```bash
+for m in raspberrypi4 raspberrypi5; do
+  sed -i "s/^MACHINE.*/MACHINE ?= \"$m\"/" conf/local.conf
+  bitbake core-image-base
+done
+```
+
+The provided GitHub workflow uses a similar approach with a build matrix to
+automatically produce images for Raspberry Pi 3, 4 and 5 and attaches them to a
+release when triggered from a tag.
+
 ## 3. Add OWL to the image
 
 1. Add a custom layer (e.g. `meta-owl`) to package the OWL application. This layer should provide a recipe that installs OWL and its Python dependencies.

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -24,3 +24,5 @@ OpenWeedLocator packaging
 
 - Updated Yocto build workflow to install lz4 and zstd host tools.
 - Added docs/yocto-extras.md describing additional packages, services, and configuration options in the OWL Yocto image.
+- Workflow now builds images for Raspberry Pi 3, 4 and 5 using a build matrix.
+- Added step to upload built images to GitHub Releases when a tag is published.


### PR DESCRIPTION
## Summary
- document how to build images for multiple Raspberry Pi models
- build Yocto images for Pi3/4/5 via matrix workflow
- upload built images as release assets when tagging
- note the new workflow behaviour in packaging notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
