### PR TITLE
Add checksum and compression steps to Yocto build

### DIFF
--- a/.github/workflows/yocto-build.yml
+++ b/.github/workflows/yocto-build.yml
@@ -24,7 +24,7 @@ jobs:
             build-essential chrpath socat cpio python3 python3-pip python3-pexpect \
             xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1 \
             libsdl1.2-dev pylint xterm bc bison flex libssl-dev libncurses5-dev \
-            lz4 zstd
+            lz4 zstd bzip2 bmap-tools
 
       - name: Set up Yocto environment
         run: |
@@ -40,15 +40,30 @@ jobs:
           echo 'MACHINE ?= "${{ matrix.machine }}"' >> conf/local.conf
           bitbake core-image-base
 
+      - name: Prepare release artifacts
+        run: |
+          cd poky/build/tmp/deploy/images
+          find . -name 'core-image-base*.wic' -print0 | while IFS= read -r -d '' img; do
+            bmaptool create "$img" -o "$img.bmap"
+            bzip2 -f "$img"
+            sha256sum "$img.bz2" "$img.bmap" >> "$GITHUB_WORKSPACE/SHA256SUMS"
+          done
+
       - name: Upload image artifact
         uses: actions/upload-artifact@v4
         with:
           name: yocto-image
-          path: poky/build/tmp/deploy/images/**/core-image-base*.wic
+          path: |
+            poky/build/tmp/deploy/images/**/core-image-base*.wic.bz2
+            poky/build/tmp/deploy/images/**/core-image-base*.wic.bmap
+            SHA256SUMS
 
       - name: Upload release asset
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: poky/build/tmp/deploy/images/**/core-image-base*.wic
+          files: |
+            poky/build/tmp/deploy/images/**/core-image-base*.wic.bz2
+            poky/build/tmp/deploy/images/**/core-image-base*.wic.bmap
+            SHA256SUMS
 

--- a/docs/yocto.md
+++ b/docs/yocto.md
@@ -60,7 +60,9 @@ done
 
 The provided GitHub workflow uses a similar approach with a build matrix to
 automatically produce images for Raspberry Pi 3, 4 and 5 and attaches them to a
-release when triggered from a tag.
+release when triggered from a tag. The workflow also compresses each `.wic`
+image with `bzip2`, creates a corresponding `.bmap` file and generates a
+`SHA256SUMS` file for verification.
 
 ## 3. Add OWL to the image
 

--- a/notes/packaging_notes.txt
+++ b/notes/packaging_notes.txt
@@ -26,3 +26,5 @@ OpenWeedLocator packaging
 - Added docs/yocto-extras.md describing additional packages, services, and configuration options in the OWL Yocto image.
 - Workflow now builds images for Raspberry Pi 3, 4 and 5 using a build matrix.
 - Added step to upload built images to GitHub Releases when a tag is published.
+- Workflow now compresses `.wic` images, generates `.bmap` files, and creates a
+  `SHA256SUMS` file for release assets.


### PR DESCRIPTION
## Summary
- install `bzip2` and `bmap-tools` for Yocto builds
- compress `.wic` images, create `.bmap` files and collect SHA256 sums
- include these files in uploaded artifacts and releases
- document new release assets in `docs/yocto.md`
- record packaging update in notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
